### PR TITLE
Validação de Email e Url

### DIFF
--- a/FluentValidator/ValidationContract.cs
+++ b/FluentValidator/ValidationContract.cs
@@ -95,7 +95,7 @@ namespace FluentValidator
             var val = selector.Compile().Invoke(_validatable);
             var name = ((MemberExpression)selector.Body).Member.Name;
 
-            if (!string.IsNullOrEmpty(val) && !Regex.IsMatch(val, @"^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$"))
+            if (string.IsNullOrEmpty(val) || !Regex.IsMatch(val, @"^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$"))
                 _validatable.AddNotification(name, string.IsNullOrEmpty(message) ? $"Field {name} must be a valid E-mail address." : message);
 
             return this;
@@ -112,7 +112,7 @@ namespace FluentValidator
             var val = selector.Compile().Invoke(_validatable);
             var name = ((MemberExpression)selector.Body).Member.Name;
 
-            if (!string.IsNullOrEmpty(val) && !Regex.IsMatch(val, @"^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$"))
+            if (string.IsNullOrEmpty(val) || !Regex.IsMatch(val, @"^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$"))
                 _validatable.AddNotification(name, string.IsNullOrEmpty(message) ? $"Field {name} must be a valid URL." : message);
 
             return this;


### PR DESCRIPTION
Quando passamos um email ou url vazio, o método não está adicionando notificações e tornando o objeto válido.