### PR TITLE
Support notification messages with parameters

### DIFF
--- a/FluentValidator.Tests/DateTimeValidationContractTests.cs
+++ b/FluentValidator.Tests/DateTimeValidationContractTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentValidator.Validation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Linq;
 
 namespace FluentValidator.Tests
 {
@@ -36,6 +37,22 @@ namespace FluentValidator.Tests
 
         [TestMethod]
         [TestCategory("DateTimeValidation")]
+        public void IsGreaterThanWithParameters()
+        {
+            _dummy = new Dummy { dateTimeProp = new DateTime(2005, 5, 15, 16, 0, 0) };
+            var comparer = _dummy.dateTimeProp.AddMilliseconds(1);
+
+            var wrong = new ValidationContract()
+                .Requires()
+                .IsGreaterThan(_dummy.dateTimeProp, comparer, nameof(_dummy.dateTimeProp), "Date {0:dd/MM/yyyy HH:mm:ss} should be greater than Date {1:D}");
+
+            var message = wrong.Notifications.First().Message;
+
+            Assert.AreEqual($"Date {_dummy.dateTimeProp:dd/MM/yyyy HH:mm:ss} should be greater than Date {comparer:D}", message);
+        }
+
+        [TestMethod]
+        [TestCategory("DateTimeValidation")]
         public void IsGreaterOrEqualsThan()
         {
             _dummy = new Dummy();
@@ -58,6 +75,25 @@ namespace FluentValidator.Tests
                 .IsGreaterOrEqualsThan(_dummy.dateTimeProp, _dummy.dateTimeProp.AddMinutes(-1), nameof(_dummy.dateTimeProp), "Date 1 is not greater or equals than Date 2");
 
             Assert.AreEqual(true, right.IsValid);
+        }
+
+
+        [TestMethod]
+        [TestCategory("DateTimeValidation")]
+        public void IsGreaterOrEqualsThanWithParameters()
+        {
+            _dummy = new Dummy();
+            _dummy.dateTimeProp = new DateTime(2017, 1, 1, 12, 0, 0);
+            var comparer = _dummy.dateTimeProp.AddMilliseconds(1);
+
+            var wrong = new ValidationContract()
+                .Requires()
+                .IsGreaterOrEqualsThan(_dummy.dateTimeProp, comparer, nameof(_dummy.dateTimeProp),
+                    "Date {0} is not greater or equals than Date {1}");
+
+            var message = wrong.Notifications.First().Message;
+
+            Assert.AreEqual($"Date {_dummy.dateTimeProp} is not greater or equals than Date {comparer}", message);
         }
 
         [TestMethod]
@@ -87,6 +123,26 @@ namespace FluentValidator.Tests
 
         [TestMethod]
         [TestCategory("DateTimeValidation")]
+        public void IsLowerThanWithParameters()
+        {
+            _dummy = new Dummy();
+            _dummy.dateTimeProp = new DateTime(2017, 9, 26, 15, 0, 0);
+            var comparer = _dummy.dateTimeProp.AddMilliseconds(-1);
+
+            var wrong = new ValidationContract()
+                .Requires()
+                .IsLowerThan(_dummy.dateTimeProp, comparer, nameof(_dummy.dateTimeProp),
+                    "Date {0} should be lower than Date {1}");
+
+
+
+            var message = wrong.Notifications.First().Message;
+
+            Assert.AreEqual($"Date {_dummy.dateTimeProp} should be lower than Date {comparer}", message);
+        }
+
+        [TestMethod]
+        [TestCategory("DateTimeValidation")]
         public void IsLowerOrEqualsThan()
         {
             _dummy = new Dummy();
@@ -109,6 +165,26 @@ namespace FluentValidator.Tests
                 .IsLowerOrEqualsThan(_dummy.dateTimeProp, _dummy.dateTimeProp.AddMinutes(1), nameof(_dummy.dateTimeProp), "Date 1 is not lower or equals than Date 2");
 
             Assert.AreEqual(true, right.IsValid);
-        }       
+        }
+
+        [TestMethod]
+        [TestCategory("DateTimeValidation")]
+        public void IsLowerOrEqualsThanWithParameters()
+        {
+            _dummy = new Dummy();
+            _dummy.dateTimeProp = new DateTime(2005, 5, 15, 16, 0, 0);
+            var comparer = _dummy.dateTimeProp.AddMilliseconds(-1);
+
+            var wrong = new ValidationContract()
+                .Requires()
+                .IsLowerOrEqualsThan(_dummy.dateTimeProp, comparer, nameof(_dummy.dateTimeProp),
+                    "Date {0} should be lower than Date {1}");
+
+
+
+            var message = wrong.Notifications.First().Message;
+
+            Assert.AreEqual($"Date {_dummy.dateTimeProp} should be lower than Date {comparer}", message);
+        }
     }
 }

--- a/FluentValidator.Tests/DecimalValidationContractTests.cs
+++ b/FluentValidator.Tests/DecimalValidationContractTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidator.Validation;
+﻿using System.Linq;
+using FluentValidator.Validation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace FluentValidator.Tests
@@ -29,6 +30,22 @@ namespace FluentValidator.Tests
 
         [TestMethod]
         [TestCategory("DecimalValidation")]
+        public void IsGreaterThanDecimalWithParameters()
+        {
+            decimal v1 = 5;
+            decimal v2 = 10;
+            var message = new ValidationContract()
+                .Requires()
+                .IsGreaterThan(v1, v2, "decimal", "{0} is not greater than {1}")
+                .Notifications
+                .First()
+                .Message;
+
+            Assert.AreEqual($"{v1} is not greater than {v2}", message);
+        }
+
+        [TestMethod]
+        [TestCategory("DecimalValidation")]
         public void IsGreaterThanDouble()
         {
             double v1 = 5;
@@ -47,6 +64,22 @@ namespace FluentValidator.Tests
                 .IsGreaterThan(v1, v2, "decimal", "V1 is not greater than v2");
 
             Assert.AreEqual(true, right.IsValid);
+        }
+
+        [TestMethod]
+        [TestCategory("DecimalValidation")]
+        public void IsGreaterThanDoubleWithParameters()
+        {
+            double v1 = 5;
+            decimal v2 = 10;
+            var message = new ValidationContract()
+                .Requires()
+                .IsGreaterThan(v1, v2, "decimal", "{0} is not greater than {1}")
+                .Notifications
+                .First()
+                .Message;
+
+            Assert.AreEqual(message, $"{v1} is not greater than {v2}");
         }
 
         [TestMethod]
@@ -73,6 +106,22 @@ namespace FluentValidator.Tests
 
         [TestMethod]
         [TestCategory("DecimalValidation")]
+        public void IsGreaterThanFloatWithParameters()
+        {
+            float v1 = 5;
+            decimal v2 = 10;
+            var message = new ValidationContract()
+                .Requires()
+                .IsGreaterThan(v1, v2, "decimal", "{0} is not greater than {1}")
+                .Notifications
+                .First()
+                .Message;
+
+           Assert.AreEqual($"{v1} is not greater than {v2}", message);
+        }
+
+        [TestMethod]
+        [TestCategory("DecimalValidation")]
         public void IsGreaterThanInt()
         {
             int v1 = 5;
@@ -89,6 +138,24 @@ namespace FluentValidator.Tests
                 .IsGreaterThan(v2, v1, "decimal", "V1 is not greater than v2");
 
             Assert.AreEqual(true, right.IsValid);
+        }
+
+        [TestMethod]
+        [TestCategory("DecimalValidation")]
+        public void IsGreaterThanIntWithParameters()
+        {
+            int v1 = 5;
+            decimal v2 = 10;
+
+            var message = new ValidationContract()
+                .Requires()
+                .IsGreaterThan(v1, v2, "decimal", "{0:C} is not greater than {1}")
+                .Notifications
+                .First()
+                .Message;
+
+            Assert.AreEqual($"{v1:C} is not greater than {v2}", message);
+            
         }
     }
 }

--- a/FluentValidator.Tests/NotifiableTests.cs
+++ b/FluentValidator.Tests/NotifiableTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace FluentValidator.Tests
 {
@@ -9,15 +11,40 @@ namespace FluentValidator.Tests
         [TestCategory("Notifiable")]
         public void AddNotificationForOneNotifiable()
         {
-            var name =new Name();
+            var name = new Name();
             var cus = new Customer();
 
             AddNotifications(name);
             AddNotifications(cus);
 
             Assert.AreEqual(false, IsValid);
-            Assert.AreEqual(2, Notifications.Count);            
+            Assert.AreEqual(2, Notifications.Count);
         }
+
+        [TestMethod]
+        [TestCategory("Notifiable")]
+        public void AddNotificationForOneNotifiableWithParameters()
+        {
+            var cus = new Customer(anotherParam: "with message");
+
+            AddNotifications(cus);
+            var notification = cus.Notifications.First();
+
+            Assert.AreEqual("Testing with message", notification.Message);
+        }
+
+        [TestMethod]
+        [TestCategory("Notifiable")]
+        public void AddNotificationWithNullParameter()
+        {
+            var cus = new Customer(anotherParam: null);
+
+            AddNotifications(cus);
+            var notification = cus.Notifications.First();
+
+            Assert.AreEqual("Testing ", notification.Message);
+        }
+
 
         [TestMethod]
         [TestCategory("Notifiable")]
@@ -35,9 +62,9 @@ namespace FluentValidator.Tests
 
     public class Customer : Notifiable
     {
-        public Customer()
+        public Customer(string message = "Testing", string anotherParam = null)
         {
-            AddNotification("Test", "Testing");
+            AddNotification("Test", $"{message} {{0}}", anotherParam);
         }
 
         public Name Name { get; set; }
@@ -47,7 +74,7 @@ namespace FluentValidator.Tests
     {
         public Name()
         {
-            AddNotification("Test", "Testing");
+            AddNotification("Test", "Testing", FirstName, LastName);
         }
 
         public string FirstName { get; set; }

--- a/FluentValidator.Tests/StringValidationContractTests.cs
+++ b/FluentValidator.Tests/StringValidationContractTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FluentValidator.Validation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -42,6 +43,8 @@ namespace FluentValidator.Tests
             Assert.AreEqual(false, wrong.IsValid);
         }
 
+
+
         [TestMethod]
         [TestCategory("StringValidation")]
         public void MinLen()
@@ -58,6 +61,19 @@ namespace FluentValidator.Tests
                 .HasMinLen("Some Valid String", 5, "string", "String len is less than permited");
 
             Assert.AreEqual(true, right.IsValid);
+        }
+
+        [TestMethod]
+        [TestCategory("StringValidation")]
+        public void MinLenWithParameters()
+        {
+            var wrong = new ValidationContract()
+                .Requires()
+                .HasMinLen("null", 5,"string", "String must have at least {1} characters.");
+
+            var notification = wrong.Notifications.First();
+
+            Assert.AreEqual("String must have at least 5 characters.", notification.Message);
         }
 
         [TestMethod]
@@ -80,6 +96,17 @@ namespace FluentValidator.Tests
 
         [TestMethod]
         [TestCategory("StringValidation")]
+        public void MaxLenWithParameters()
+        {
+            var x = new ValidationContract()
+                .Requires()
+                .HasMaxLen("null", 3, "string", "String len is more than {1}");
+
+            Assert.AreEqual("String len is more than 3", x.Notifications.First().Message);
+        }
+
+        [TestMethod]
+        [TestCategory("StringValidation")]
         public void Len()
         {
             var x = new ValidationContract()
@@ -94,6 +121,19 @@ namespace FluentValidator.Tests
                 .HasLen("Some1", 5, "string", "String len is less than permited");
 
             Assert.AreEqual(true, right.IsValid);
+        }
+
+        [TestMethod]
+        [TestCategory("StringValidation")]
+        public void LenWithParameters()
+        {
+            var x = new ValidationContract()
+                .Requires()
+                .HasLen("null", 3, "string", "{0} len is more than {1}")
+                .Notifications
+                .First();
+
+            Assert.AreEqual("null len is more than 3", x.Message);
         }
 
         [TestMethod]
@@ -116,6 +156,17 @@ namespace FluentValidator.Tests
 
         [TestMethod]
         [TestCategory("StringValidation")]
+        public void ContainsWithParameters()
+        {
+            var x = new ValidationContract()
+                .Requires()
+                .Contains("some text here", "banana", "string", "{0} does not contains {1}");
+
+            Assert.AreEqual("some text here does not contains banana", x.Notifications.First().Message);
+        }
+
+        [TestMethod]
+        [TestCategory("StringValidation")]
         public void Email()
         {
             var wrong = new ValidationContract()
@@ -130,6 +181,19 @@ namespace FluentValidator.Tests
                 .IsEmail("andrebaltieri@gmail.com", "string", "Invalid E-mail");
 
             Assert.AreEqual(true, right.IsValid);
+        }
+
+        [TestMethod]
+        public void EmailWithParameters()
+        {
+            var wrong = new ValidationContract()
+                .Requires()
+                .IsEmail("wrongemail", "string", "Email should match the pattern {0}");
+
+            var message = wrong.Notifications.First().Message;
+            var pattern = @"^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$";
+
+            Assert.AreEqual($"Email should match the pattern {pattern}", message);
         }
 
         [TestMethod]
@@ -151,6 +215,7 @@ namespace FluentValidator.Tests
 
             Assert.AreEqual(true, right.IsValid);
         }
+        
 
         [TestMethod]
         [TestCategory("StringValidation")]

--- a/FluentValidator/Notifications/Notifiable.cs
+++ b/FluentValidator/Notifications/Notifiable.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace FluentValidator
@@ -13,6 +14,14 @@ namespace FluentValidator
         public void AddNotification(string property, string message)
         {
             _notifications.Add(new Notification(property, message));
+        }
+
+        public void AddNotification(string property, string message, params object[] parameters)
+        {
+            parameters = parameters ?? new object[] { };
+
+            var formattedMessage = string.Format(message, parameters);
+            AddNotification(property, formattedMessage);
         }
 
         public void AddNotification(Notification notification)
@@ -42,7 +51,7 @@ namespace FluentValidator
 
         public void AddNotifications(params Notifiable[] items)
         {
-            foreach (var item in items)
+            foreach(var item in items)
                 AddNotifications(item);
         }
 

--- a/FluentValidator/Validation/DateTimeValidationContract.cs
+++ b/FluentValidator/Validation/DateTimeValidationContract.cs
@@ -7,7 +7,7 @@ namespace FluentValidator.Validation
         public ValidationContract IsGreaterThan(DateTime val, DateTime comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -15,7 +15,7 @@ namespace FluentValidator.Validation
         public ValidationContract IsGreaterOrEqualsThan(DateTime val, DateTime comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -23,7 +23,7 @@ namespace FluentValidator.Validation
         public ValidationContract IsLowerThan(DateTime val, DateTime comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -31,7 +31,7 @@ namespace FluentValidator.Validation
         public ValidationContract IsLowerOrEqualsThan(DateTime val, DateTime comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }

--- a/FluentValidator/Validation/DecimalValidationContract.cs
+++ b/FluentValidator/Validation/DecimalValidationContract.cs
@@ -6,7 +6,7 @@
         public ValidationContract IsGreaterThan(decimal val, decimal comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -14,7 +14,7 @@
         public ValidationContract IsGreaterThan(double val, decimal comparer, string property, string message)
         {
             if (val <= (double)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -22,7 +22,7 @@
         public ValidationContract IsGreaterThan(float val, decimal comparer, string property, string message)
         {
             if (val <= (float)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -30,7 +30,7 @@
         public ValidationContract IsGreaterThan(int val, decimal comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -40,7 +40,7 @@
         public ValidationContract IsGreaterOrEqualsThan(decimal val, decimal comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -48,7 +48,7 @@
         public ValidationContract IsGreaterOrEqualsThan(double val, decimal comparer, string property, string message)
         {
             if (val < (double)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -56,7 +56,7 @@
         public ValidationContract IsGreaterOrEqualsThan(float val, decimal comparer, string property, string message)
         {
             if (val < (float)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -64,7 +64,7 @@
         public ValidationContract IsGreaterOrEqualsThan(int val, decimal comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -74,7 +74,7 @@
         public ValidationContract IsLowerThan(decimal val, decimal comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -82,7 +82,7 @@
         public ValidationContract IsLowerThan(double val, decimal comparer, string property, string message)
         {
             if (val >= (double)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -90,7 +90,7 @@
         public ValidationContract IsLowerThan(float val, decimal comparer, string property, string message)
         {
             if (val >= (float)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -98,7 +98,7 @@
         public ValidationContract IsLowerThan(int val, decimal comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -108,7 +108,7 @@
         public ValidationContract IsLowerOrEqualsThan(decimal val, decimal comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -116,7 +116,7 @@
         public ValidationContract IsLowerOrEqualsThan(double val, decimal comparer, string property, string message)
         {
             if (val > (double)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -124,7 +124,7 @@
         public ValidationContract IsLowerOrEqualsThan(float val, decimal comparer, string property, string message)
         {
             if (val > (float)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -132,7 +132,7 @@
         public ValidationContract IsLowerOrEqualsThan(int val, decimal comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -142,7 +142,7 @@
         public ValidationContract AreEquals(decimal val, decimal comparer, string property, string message)
         {
             if (val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -150,7 +150,7 @@
         public ValidationContract AreEquals(double val, decimal comparer, string property, string message)
         {
             if (val != (double)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -158,7 +158,7 @@
         public ValidationContract AreEquals(float val, decimal comparer, string property, string message)
         {
             if (val != (float)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -166,7 +166,7 @@
         public ValidationContract AreEquals(int val, decimal comparer, string property, string message)
         {
             if (val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -176,7 +176,7 @@
         public ValidationContract AreNotEquals(decimal val, decimal comparer, string property, string message)
         {
             if (val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -184,7 +184,7 @@
         public ValidationContract AreNotEquals(double val, decimal comparer, string property, string message)
         {
             if (val == (double)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -192,7 +192,7 @@
         public ValidationContract AreNotEquals(float val, decimal comparer, string property, string message)
         {
             if (val == (float)comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -200,7 +200,7 @@
         public ValidationContract AreNotEquals(int val, decimal comparer, string property, string message)
         {
             if (val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }

--- a/FluentValidator/Validation/DoubleValidationContract.cs
+++ b/FluentValidator/Validation/DoubleValidationContract.cs
@@ -6,7 +6,7 @@
         public ValidationContract IsGreaterThan(decimal val, double comparer, string property, string message)
         {
             if ((double)val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -14,7 +14,7 @@
         public ValidationContract IsGreaterThan(double val, double comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -22,7 +22,7 @@
         public ValidationContract IsGreaterThan(float val, double comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -30,7 +30,7 @@
         public ValidationContract IsGreaterThan(int val, double comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -40,7 +40,7 @@
         public ValidationContract IsGreaterOrEqualsThan(decimal val, double comparer, string property, string message)
         {
             if ((double)val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -48,7 +48,7 @@
         public ValidationContract IsGreaterOrEqualsThan(double val, double comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -56,7 +56,7 @@
         public ValidationContract IsGreaterOrEqualsThan(float val, double comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -64,7 +64,7 @@
         public ValidationContract IsGreaterOrEqualsThan(int val, double comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -74,7 +74,7 @@
         public ValidationContract IsLowerThan(decimal val, double comparer, string property, string message)
         {
             if ((double)val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -82,7 +82,7 @@
         public ValidationContract IsLowerThan(double val, double comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -90,7 +90,7 @@
         public ValidationContract IsLowerThan(float val, double comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -98,7 +98,7 @@
         public ValidationContract IsLowerThan(int val, double comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -108,7 +108,7 @@
         public ValidationContract IsLowerOrEqualsThan(decimal val, double comparer, string property, string message)
         {
             if ((double)val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -116,7 +116,7 @@
         public ValidationContract IsLowerOrEqualsThan(double val, double comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -124,7 +124,7 @@
         public ValidationContract IsLowerOrEqualsThan(float val, double comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -132,7 +132,7 @@
         public ValidationContract IsLowerOrEqualsThan(int val, double comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -142,7 +142,7 @@
         public ValidationContract AreEquals(decimal val, double comparer, string property, string message)
         {
             if ((double)val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -150,7 +150,7 @@
         public ValidationContract AreEquals(double val, double comparer, string property, string message)
         {
             if (val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -158,7 +158,7 @@
         public ValidationContract AreEquals(float val, double comparer, string property, string message)
         {
             if (val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -166,7 +166,7 @@
         public ValidationContract AreEquals(int val, double comparer, string property, string message)
         {
             if (val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -176,7 +176,7 @@
         public ValidationContract AreNotEquals(decimal val, double comparer, string property, string message)
         {
             if ((double)val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -184,7 +184,7 @@
         public ValidationContract AreNotEquals(double val, double comparer, string property, string message)
         {
             if (val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -192,7 +192,7 @@
         public ValidationContract AreNotEquals(float val, double comparer, string property, string message)
         {
             if (val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -200,7 +200,7 @@
         public ValidationContract AreNotEquals(int val, double comparer, string property, string message)
         {
             if (val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }

--- a/FluentValidator/Validation/FloatValidationContract.cs
+++ b/FluentValidator/Validation/FloatValidationContract.cs
@@ -6,7 +6,7 @@
         public ValidationContract IsGreaterThan(decimal val, float comparer, string property, string message)
         {
             if ((double)val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -14,7 +14,7 @@
         public ValidationContract IsGreaterThan(double val, float comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -22,7 +22,7 @@
         public ValidationContract IsGreaterThan(float val, float comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -30,7 +30,7 @@
         public ValidationContract IsGreaterThan(int val, float comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -40,7 +40,7 @@
         public ValidationContract IsGreaterOrEqualsThan(decimal val, float comparer, string property, string message)
         {
             if ((double)val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -48,7 +48,7 @@
         public ValidationContract IsGreaterOrEqualsThan(double val, float comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -56,7 +56,7 @@
         public ValidationContract IsGreaterOrEqualsThan(float val, float comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -64,7 +64,7 @@
         public ValidationContract IsGreaterOrEqualsThan(int val, float comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -82,7 +82,7 @@
         public ValidationContract IsLowerThan(double val, float comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -90,7 +90,7 @@
         public ValidationContract IsLowerThan(float val, float comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -98,7 +98,7 @@
         public ValidationContract IsLowerThan(int val, float comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -108,7 +108,7 @@
         public ValidationContract IsLowerOrEqualsThan(decimal val, float comparer, string property, string message)
         {
             if ((double)val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -116,7 +116,7 @@
         public ValidationContract IsLowerOrEqualsThan(double val, float comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -124,7 +124,7 @@
         public ValidationContract IsLowerOrEqualsThan(float val, float comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -132,7 +132,7 @@
         public ValidationContract IsLowerOrEqualsThan(int val, float comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -142,7 +142,7 @@
         public ValidationContract AreEquals(decimal val, float comparer, string property, string message)
         {
             if ((double)val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -150,7 +150,7 @@
         public ValidationContract AreEquals(double val, float comparer, string property, string message)
         {
             if (val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -166,7 +166,7 @@
         public ValidationContract AreEquals(int val, float comparer, string property, string message)
         {
             if (val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -176,7 +176,7 @@
         public ValidationContract AreNotEquals(decimal val, float comparer, string property, string message)
         {
             if ((double)val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -184,7 +184,7 @@
         public ValidationContract AreNotEquals(double val, float comparer, string property, string message)
         {
             if (val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -192,7 +192,7 @@
         public ValidationContract AreNotEquals(float val, float comparer, string property, string message)
         {
             if (val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -200,7 +200,7 @@
         public ValidationContract AreNotEquals(int val, float comparer, string property, string message)
         {
             if (val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }

--- a/FluentValidator/Validation/GuidValidationContract.cs
+++ b/FluentValidator/Validation/GuidValidationContract.cs
@@ -8,7 +8,7 @@ namespace FluentValidator.Validation
         {
             // TODO: StringComparison.OrdinalIgnoreCase not suported yet
             if (val.ToString() != comparer.ToString())
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -17,7 +17,7 @@ namespace FluentValidator.Validation
         {
             // TODO: StringComparison.OrdinalIgnoreCase not suported yet
             if (val.ToString() == comparer.ToString())
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }

--- a/FluentValidator/Validation/IntValidationContract.cs
+++ b/FluentValidator/Validation/IntValidationContract.cs
@@ -6,7 +6,7 @@
         public ValidationContract IsGreaterThan(decimal val, int comparer, string property, string message)
         {
             if ((double)val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -14,7 +14,7 @@
         public ValidationContract IsGreaterThan(double val, int comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -22,7 +22,7 @@
         public ValidationContract IsGreaterThan(float val, int comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -30,7 +30,7 @@
         public ValidationContract IsGreaterThan(int val, int comparer, string property, string message)
         {
             if (val <= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -40,7 +40,7 @@
         public ValidationContract IsGreaterOrEqualsThan(decimal val, int comparer, string property, string message)
         {
             if ((double)val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -48,7 +48,7 @@
         public ValidationContract IsGreaterOrEqualsThan(double val, int comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -56,7 +56,7 @@
         public ValidationContract IsGreaterOrEqualsThan(float val, int comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -64,7 +64,7 @@
         public ValidationContract IsGreaterOrEqualsThan(int val, int comparer, string property, string message)
         {
             if (val < comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -74,7 +74,7 @@
         public ValidationContract IsLowerThan(decimal val, int comparer, string property, string message)
         {
             if ((double)val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -82,7 +82,7 @@
         public ValidationContract IsLowerThan(double val, int comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -90,7 +90,7 @@
         public ValidationContract IsLowerThan(float val, int comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -98,7 +98,7 @@
         public ValidationContract IsLowerThan(int val, int comparer, string property, string message)
         {
             if (val >= comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -108,7 +108,7 @@
         public ValidationContract IsLowerOrEqualsThan(decimal val, int comparer, string property, string message)
         {
             if ((double)val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -116,7 +116,7 @@
         public ValidationContract IsLowerOrEqualsThan(double val, int comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -124,7 +124,7 @@
         public ValidationContract IsLowerOrEqualsThan(float val, int comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -132,7 +132,7 @@
         public ValidationContract IsLowerOrEqualsThan(int val, int comparer, string property, string message)
         {
             if (val > comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -142,7 +142,7 @@
         public ValidationContract AreEquals(decimal val, int comparer, string property, string message)
         {
             if ((double)val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -150,7 +150,7 @@
         public ValidationContract AreEquals(double val, int comparer, string property, string message)
         {
             if (val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -158,7 +158,7 @@
         public ValidationContract AreEquals(float val, int comparer, string property, string message)
         {
             if (val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -166,7 +166,7 @@
         public ValidationContract AreEquals(int val, int comparer, string property, string message)
         {
             if (val != comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -176,7 +176,7 @@
         public ValidationContract AreNotEquals(decimal val, int comparer, string property, string message)
         {
             if ((double)val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -184,7 +184,7 @@
         public ValidationContract AreNotEquals(double val, int comparer, string property, string message)
         {
             if (val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -192,7 +192,7 @@
         public ValidationContract AreNotEquals(float val, int comparer, string property, string message)
         {
             if (val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }
@@ -200,7 +200,7 @@
         public ValidationContract AreNotEquals(int val, int comparer, string property, string message)
         {
             if (val == comparer)
-                AddNotification(property, message);
+                AddNotification(property, message, val, comparer);
 
             return this;
         }

--- a/FluentValidator/Validation/StringValidationContract.cs
+++ b/FluentValidator/Validation/StringValidationContract.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace FluentValidator.Validation
@@ -6,40 +7,40 @@ namespace FluentValidator.Validation
     {
         public ValidationContract IsNotNullOrEmpty(string val, string property, string message)
         {
-            if (string.IsNullOrEmpty(val))
-                AddNotification(property, message);
+            if(string.IsNullOrEmpty(val))
+                AddNotification(property, message, val);
 
             return this;
         }
 
         public ValidationContract IsNullOrEmpty(string val, string property, string message)
         {
-            if (!string.IsNullOrEmpty(val))
-                AddNotification(property, message);
+            if(!string.IsNullOrEmpty(val))
+                AddNotification(property, message, val);
 
             return this;
         }
 
         public ValidationContract HasMinLen(string val, int min, string property, string message)
         {
-            if (val.Length < min)
-                AddNotification(property, message);
+            if(val.Length < min)
+                AddNotification(property, message, val, min);
 
             return this;
         }
 
         public ValidationContract HasMaxLen(string val, int max, string property, string message)
         {
-            if (val.Length > max)
-                AddNotification(property, message);
+            if(val.Length > max)
+                AddNotification(property, message, val, max);
 
             return this;
         }
 
         public ValidationContract HasLen(string val, int len, string property, string message)
         {
-            if (val.Length != len)
-                AddNotification(property, message);
+            if(val.Length != len)
+                AddNotification(property, message, val, len);
 
             return this;
         }
@@ -47,8 +48,8 @@ namespace FluentValidator.Validation
         public ValidationContract Contains(string val, string text, string property, string message)
         {
             // TODO: StringComparison.OrdinalIgnoreCase not suported yet
-            if (!val.Contains(text))
-                AddNotification(property, message);
+            if(!val.Contains(text))
+                AddNotification(property, message, val, text);
 
             return this;
         }
@@ -56,8 +57,8 @@ namespace FluentValidator.Validation
         public ValidationContract AreEquals(string val, string text, string property, string message)
         {
             // TODO: StringComparison.OrdinalIgnoreCase not suported yet
-            if (val != text)
-                AddNotification(property, message);
+            if(val != text)
+                AddNotification(property, message, val, text);
 
             return this;
         }
@@ -65,8 +66,8 @@ namespace FluentValidator.Validation
         public ValidationContract AreNotEquals(string val, string text, string property, string message)
         {
             // TODO: StringComparison.OrdinalIgnoreCase not suported yet
-            if (val == text)
-                AddNotification(property, message);
+            if(val == text)
+                AddNotification(property, message, val, text);
 
             return this;
         }
@@ -85,8 +86,8 @@ namespace FluentValidator.Validation
 
         public ValidationContract Matchs(string text, string pattern, string property, string message)
         {
-            if (!Regex.IsMatch(text, pattern))
-                AddNotification(property, message);
+            if(!Regex.IsMatch(text, pattern))
+                AddNotification(property, message, pattern);
 
             return this;
         }


### PR DESCRIPTION
Added support to use notification parameters in messages e.g:

```c#
new ValidationContract()
.Requires()
.Contains("my text", "banana", "message", "{0} does not contains {1}"); 

// my text does not contains banana