### PR TITLE
When the IsMatch method receives a null value in input, then it is se…

### DIFF
--- a/FluentValidator/Validation/StringValidationContract.cs
+++ b/FluentValidator/Validation/StringValidationContract.cs
@@ -85,7 +85,7 @@ namespace FluentValidator.Validation
 
         public ValidationContract Matchs(string text, string pattern, string property, string message)
         {
-            if (!Regex.IsMatch(text, pattern))
+            if (!Regex.IsMatch(text ?? "", pattern))
                 AddNotification(property, message);
 
             return this;


### PR DESCRIPTION
When the IsMatch method receives a null value in input, then it is set as an empty string. Avoiding a break by exception.